### PR TITLE
fix: properly track loading state during message generation

### DIFF
--- a/Prysm/ViewModels/ChatViewModel.swift
+++ b/Prysm/ViewModels/ChatViewModel.swift
@@ -71,7 +71,8 @@ final class ChatViewModel {
 
     @MainActor
     func sendMessage(_ content: String) async {
-        isLoading = session.isResponding
+        isLoading = true
+        defer { isLoading = false }
 
         do {
             // Check if we need to apply sliding window BEFORE sending
@@ -95,8 +96,6 @@ final class ChatViewModel {
             errorMessage = handleFoundationModelsError(error)
             showError = true
         }
-
-        isLoading = session.isResponding
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Fixes `isLoading` in `ChatViewModel.sendMessage()` to be manually managed (`true` at start, `false` via `defer`) instead of relying on `session.isResponding`, which was always `false` at the points it was read
- Prevents users from sending concurrent requests during generation, which could corrupt the conversation

## Test plan
- [ ] Verify the send button is disabled while a response is streaming
- [ ] Verify the send button re-enables after the response completes
- [ ] Verify the send button re-enables if an error occurs during generation
- [ ] Verify context window exceeded recovery still works correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)