### PR TITLE
fix: Clear Conversation History now actually clears the active chat

### DIFF
--- a/Prysm/Views/AdaptiveNavigationView.swift
+++ b/Prysm/Views/AdaptiveNavigationView.swift
@@ -61,6 +61,7 @@ struct AdaptiveNavigationView: View {
             NavigationStack {
                 SettingsView()
             }
+            .environment(chatViewModel)
             .tabItem {
                 Label(TabSelection.settings.displayName, systemImage: TabSelection.settings.systemImage)
             }
@@ -112,6 +113,7 @@ struct AdaptiveNavigationView: View {
             NavigationStack {
                 SettingsView()
             }
+            .environment(chatViewModel)
         }
     }
 }

--- a/Prysm/Views/SettingsView.swift
+++ b/Prysm/Views/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import FoundationModels
 
 struct SettingsView: View {
+    @Environment(ChatViewModel.self) private var chatViewModel
     @AppStorage("autoSaveConversations") private var autoSaveConversations = true
     @AppStorage("enableHaptics") private var enableHaptics = true
     @AppStorage("showWordCount") private var showWordCount = false
@@ -19,6 +20,7 @@ struct SettingsView: View {
     @AppStorage("fontSize") private var fontSize = "medium"
     @AppStorage("useBaseInstructions") private var useBaseInstructions = true
     @State private var showingResetAlert = false
+    @State private var showingClearHistoryAlert = false
     @State private var showingAbout = false
 
     var body: some View {
@@ -125,10 +127,18 @@ struct SettingsView: View {
             }
 
             Button {
-                clearConversationHistory()
+                showingClearHistoryAlert = true
             } label: {
                 Label("Clear Conversation History", systemImage: "trash")
                     .foregroundStyle(.red)
+            }
+            .alert("Clear Conversation History?", isPresented: $showingClearHistoryAlert) {
+                Button("Cancel", role: .cancel) { }
+                Button("Clear", role: .destructive) {
+                    clearConversationHistory()
+                }
+            } message: {
+                Text("This will clear the current conversation. This action cannot be undone.")
             }
         }
     }
@@ -236,15 +246,7 @@ struct SettingsView: View {
     }
 
     private func clearConversationHistory() {
-        // Clear UserDefaults for conversation-related data
-        UserDefaults.standard.removeObject(forKey: "conversationHistory")
-        UserDefaults.standard.removeObject(forKey: "savedTranscripts")
-
-        // Clear any stored conversation summaries
-        if let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let conversationsURL = documentsDirectory.appendingPathComponent("Conversations")
-            try? FileManager.default.removeItem(at: conversationsURL)
-        }
+        chatViewModel.clearChat()
     }
 
     private func clearCache() {
@@ -388,4 +390,5 @@ struct AboutView: View {
     NavigationStack {
         SettingsView()
     }
+    .environment(ChatViewModel())
 }


### PR DESCRIPTION
## Summary
- The "Clear Conversation History" button in Settings was a no-op — it removed UserDefaults keys (`conversationHistory`, `savedTranscripts`) and a `Conversations` directory that are never written to
- Now the SettingsView receives the `ChatViewModel` via `@Environment` and calls `clearChat()`, which resets the `LanguageModelSession` and clears feedback state
- Added a confirmation alert before clearing to prevent accidental data loss

Closes #21

## Test plan
- [ ] Open the app, send a few messages in the chat
- [ ] Navigate to Settings > Privacy & Security > Clear Conversation History
- [ ] Verify the confirmation alert appears
- [ ] Tap "Clear" and verify the conversation is actually cleared when returning to the Chat tab
- [ ] Verify canceling the alert does not clear the conversation
- [ ] Test on both compact (iPhone tab view) and regular (iPad split view) layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)