### PR TITLE
fix: wire generation options into chat ViewModel

### DIFF
--- a/Prysm/ViewModels/ChatViewModel.swift
+++ b/Prysm/ViewModels/ChatViewModel.swift
@@ -53,9 +53,46 @@ final class ChatViewModel {
     private(set) var feedbackState: [Transcript.Entry.ID: LanguageModelFeedback.Sentiment] = [:]
 
     // MARK: - Sliding Window Configuration
-    private let maxTokens = 4096
     private let windowThreshold = 0.75
-    private let targetWindowSize = 2000
+
+    // MARK: - Generation Options (read from UserDefaults / @AppStorage)
+
+    /// Reads the current generation options from UserDefaults, matching keys set by GenerationOptionsView.
+    private var generationOptions: GenerationOptions {
+        let defaults = UserDefaults.standard
+
+        let temperature = defaults.object(forKey: "temperature") as? Double ?? 0.7
+        let maxResponseTokens = defaults.object(forKey: "maxTokens") as? Int ?? 2048
+
+        return GenerationOptions(
+            temperature: temperature,
+            maximumResponseTokens: maxResponseTokens
+        )
+    }
+
+    /// Whether to stream responses (set in GenerationOptionsView).
+    private var streamResponses: Bool {
+        let defaults = UserDefaults.standard
+        return defaults.object(forKey: "streamResponses") as? Bool ?? true
+    }
+
+    /// Whether to auto-summarize when context window is exceeded (set in GenerationOptionsView).
+    private var autoSummarize: Bool {
+        let defaults = UserDefaults.standard
+        return defaults.object(forKey: "autoSummarize") as? Bool ?? true
+    }
+
+    /// Context window size for sliding window logic (set in GenerationOptionsView).
+    private var contextWindowSize: Int {
+        let defaults = UserDefaults.standard
+        let value = defaults.integer(forKey: "contextWindowSize")
+        return value > 0 ? value : 4096
+    }
+
+    /// Target window size is half the context window, used when trimming history.
+    private var targetWindowSize: Int {
+        return contextWindowSize / 2
+    }
 
     // MARK: - Initialization
 
@@ -80,11 +117,18 @@ final class ChatViewModel {
                 await applySlidingWindow()
             }
 
-            // Stream response from current session
-            let responseStream = session.streamResponse(to: Prompt(content))
+            let options = generationOptions
 
-            for try await _ in responseStream {
-                // The streaming automatically updates the session transcript
+            if streamResponses {
+                // Stream response from current session
+                let responseStream = session.streamResponse(to: Prompt(content), options: options)
+
+                for try await _ in responseStream {
+                    // The streaming automatically updates the session transcript
+                }
+            } else {
+                // Non-streaming: wait for the full response
+                _ = try await session.respond(to: Prompt(content), options: options)
             }
 
         } catch LanguageModelSession.GenerationError.exceededContextWindowSize {
@@ -140,7 +184,7 @@ final class ChatViewModel {
     // MARK: - Sliding Window Implementation
 
     private func shouldApplyWindow() -> Bool {
-        return session.transcript.isApproachingLimit(threshold: windowThreshold, maxTokens: maxTokens)
+        return session.transcript.isApproachingLimit(threshold: windowThreshold, maxTokens: contextWindowSize)
     }
 
     @MainActor
@@ -213,18 +257,31 @@ final class ChatViewModel {
 
     @MainActor
     private func handleContextWindowExceeded(userMessage: String) async {
-        isSummarizing = true
+        if autoSummarize {
+            isSummarizing = true
 
-        do {
-            let summary = try await generateConversationSummary()
-            createNewSessionWithContext(summary: summary)
-            isSummarizing = false
+            do {
+                let summary = try await generateConversationSummary()
+                createNewSessionWithContext(summary: summary)
+                isSummarizing = false
 
-            try await respondWithNewSession(to: userMessage)
-        } catch {
-            handleSummarizationError(error)
-            errorMessage = handleFoundationModelsError(error)
-            showError = true
+                try await respondWithNewSession(to: userMessage)
+            } catch {
+                handleSummarizationError(error)
+                errorMessage = handleFoundationModelsError(error)
+                showError = true
+            }
+        } else {
+            // Without auto-summarize, just start a fresh session and retry
+            session = LanguageModelSession(instructions: Instructions(instructions))
+            sessionCount += 1
+
+            do {
+                try await respondWithNewSession(to: userMessage)
+            } catch {
+                errorMessage = handleFoundationModelsError(error)
+                showError = true
+            }
         }
     }
 
@@ -300,10 +357,16 @@ final class ChatViewModel {
 
     @MainActor
     private func respondWithNewSession(to userMessage: String) async throws {
-        let responseStream = session.streamResponse(to: Prompt(userMessage))
+        let options = generationOptions
 
-        for try await _ in responseStream {
-            // The streaming automatically updates the session transcript
+        if streamResponses {
+            let responseStream = session.streamResponse(to: Prompt(userMessage), options: options)
+
+            for try await _ in responseStream {
+                // The streaming automatically updates the session transcript
+            }
+        } else {
+            _ = try await session.respond(to: Prompt(userMessage), options: options)
         }
     }
 

--- a/Prysm/Views/GenerationOptionsView.swift
+++ b/Prysm/Views/GenerationOptionsView.swift
@@ -10,7 +10,6 @@ import FoundationModels
 
 struct GenerationOptionsView: View {
     @AppStorage("temperature") private var temperature: Double = 0.7
-    @AppStorage("topP") private var topP: Double = 0.95
     @AppStorage("maxTokens") private var maxTokens: Int = 2048
     @AppStorage("streamResponses") private var streamResponses: Bool = true
     @AppStorage("autoSummarize") private var autoSummarize: Bool = true
@@ -24,7 +23,6 @@ struct GenerationOptionsView: View {
                 headerView
 
                 temperatureSection
-                topPSection
                 tokensSection
                 behaviorSection
 
@@ -83,39 +81,6 @@ struct GenerationOptionsView: View {
 
                 Slider(value: $temperature, in: 0...2, step: 0.1)
                     .tint(.purple)
-            }
-            .padding()
-            .background(.regularMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.medium))
-        }
-    }
-
-    private var topPSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.medium) {
-            Label("Focus", systemImage: "target")
-                .font(.headline)
-
-            Text("Controls the diversity of word choices")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            VStack(alignment: .leading, spacing: Spacing.small) {
-                HStack {
-                    Text("Narrow")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    Text(String(format: "%.2f", topP))
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.primary)
-                    Spacer()
-                    Text("Broad")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Slider(value: $topP, in: 0.1...1.0, step: 0.05)
-                    .tint(.blue)
             }
             .padding()
             .background(.regularMaterial)
@@ -226,11 +191,12 @@ struct GenerationOptionsView: View {
 
     private func resetToDefaults() {
         temperature = 0.7
-        topP = 0.95
         maxTokens = 2048
         streamResponses = true
         autoSummarize = true
         contextWindowSize = 4096
+        // Clean up legacy topP key
+        UserDefaults.standard.removeObject(forKey: "topP")
     }
 }
 


### PR DESCRIPTION
## Summary
- **temperature** and **maxTokens** are now passed as `GenerationOptions` to every `streamResponse`/`respond` call, so the sliders in Generation Options actually affect AI output
- **streamResponses** toggle now switches between streaming (`streamResponse`) and non-streaming (`respond`) paths
- **autoSummarize** toggle is respected: when off, context window overflow resets the session without summarizing
- **contextWindowSize** feeds into the sliding window threshold (replaces hardcoded 4096); `targetWindowSize` is derived as half the context window
- **topP** slider removed from UI because Apple's FoundationModels `GenerationOptions` does not expose a `topP` parameter (only `temperature`, `maximumResponseTokens`, and `SamplingMode`)

Closes #17

## Test plan
- [ ] Adjust temperature slider, verify responses change in creativity
- [ ] Adjust max tokens slider, verify response length is capped accordingly
- [ ] Toggle "Stream Responses" off, verify responses appear all at once instead of streaming
- [ ] Toggle "Auto-Summarize" off, have a long conversation until context overflows, verify session resets without summarization
- [ ] Adjust context window size, verify sliding window triggers at the new threshold
- [ ] Verify topP slider is no longer shown in Generation Options
- [ ] Verify "Reset to Defaults" still works and cleans up legacy topP key
- [ ] Build and run on device to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)