### PR TITLE
🐛 fix: feedback buttons now appear on AI responses

### DIFF
--- a/Prysm/Views/TranscriptEntryView.swift
+++ b/Prysm/Views/TranscriptEntryView.swift
@@ -20,7 +20,7 @@ struct TranscriptEntryView: View {
 
         case .response(let response):
             if let text = extractText(from: response.segments), !text.isEmpty {
-                MessageBubbleView(message: ChatMessage(content: text, isFromUser: false))
+                MessageBubbleView(message: ChatMessage(entryID: entry.id, content: text, isFromUser: false))
             }
 
         case .instructions:


### PR DESCRIPTION
## Summary
- **Fixes #18** — AI response `ChatMessage` objects were created without an `entryID`, so `MessageBubbleView`'s feedback thumbs-up/down buttons were never rendered.
- In `TranscriptEntryView`, the `.response` case now passes `entry.id` to the `ChatMessage` initializer, populating the `entryID` field that gates feedback button visibility.

## Test plan
- [ ] Send a message and receive an AI response
- [ ] Verify thumbs-up and thumbs-down buttons appear below the AI response bubble
- [ ] Tap each button and confirm the feedback state updates (filled icon, correct color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)