### PR TITLE
Fix tool toggles storage key migration and deterministic JSON

### DIFF
--- a/Prysm/Views/ToolsView.swift
+++ b/Prysm/Views/ToolsView.swift
@@ -8,21 +8,35 @@
 import SwiftUI
 
 struct ToolsView: View {
+    private static let defaultTools: [String] = ["summarizer", "translator", "codeFormatter"]
+
     @State private var selectedCategory: ToolCategory = .productivity
-    @AppStorage("enabledTools") private var enabledToolsData: Data = {
-        let defaults = ["summarizer", "translator", "codeFormatter"]
-        return (try? JSONEncoder().encode(defaults)) ?? Data()
+    @AppStorage("enabledToolsData") private var enabledToolsData: Data = {
+        return (try? JSONEncoder().encode(defaultTools)) ?? Data()
     }()
 
     private var enabledTools: Set<String> {
         guard let tools = try? JSONDecoder().decode([String].self, from: enabledToolsData) else {
-            return ["summarizer", "translator", "codeFormatter"]
+            return Set(Self.defaultTools)
         }
         return Set(tools)
     }
 
     private func setEnabledTools(_ tools: Set<String>) {
-        enabledToolsData = (try? JSONEncoder().encode(Array(tools))) ?? Data()
+        if let data = try? JSONEncoder().encode(tools.sorted()) {
+            enabledToolsData = data
+        }
+    }
+
+    /// Migrates legacy `enabledTools` array value to the new `enabledToolsData` JSON key.
+    private func migrateIfNeeded() {
+        let defaults = UserDefaults.standard
+        if let legacy = defaults.array(forKey: "enabledTools") as? [String] {
+            if let data = try? JSONEncoder().encode(legacy.sorted()) {
+                enabledToolsData = data
+            }
+            defaults.removeObject(forKey: "enabledTools")
+        }
     }
 
     var body: some View {
@@ -42,6 +56,7 @@ struct ToolsView: View {
 #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
 #endif
+        .onAppear { migrateIfNeeded() }
     }
 
     private var headerView: some View {

--- a/PrysmTests/SettingsTests.swift
+++ b/PrysmTests/SettingsTests.swift
@@ -27,6 +27,7 @@ struct SettingsTests {
         defaults.removeObject(forKey: "customInstructions")
         defaults.removeObject(forKey: "exportFormat")
         defaults.removeObject(forKey: "enabledTools")
+        defaults.removeObject(forKey: "enabledToolsData")
         defaults.removeObject(forKey: "selectedTheme")
         defaults.removeObject(forKey: "systemPromptStyle")
         defaults.removeObject(forKey: "enableNotifications")
@@ -131,33 +132,65 @@ struct SettingsTests {
         #expect(defaults.string(forKey: "exportFormat") == "csv")
     }
 
-    @Test("Enabled tools persistence")
+    @Test("Enabled tools persistence with JSON Data encoding")
     func testEnabledToolsPersistence() {
         defer { cleanup() }
 
         let defaults = UserDefaults.standard
 
-        // Default empty set
-        #expect(defaults.array(forKey: "enabledTools") == nil)
+        // Default: no data stored
+        #expect(defaults.data(forKey: "enabledToolsData") == nil)
 
-        // Set tools
+        // Store tools as sorted JSON array (matching ToolsView behavior)
         let tools = ["calculator", "codeInterpreter", "webSearch"]
-        defaults.set(tools, forKey: "enabledTools")
+        let encoded = try! JSONEncoder().encode(tools.sorted())
+        defaults.set(encoded, forKey: "enabledToolsData")
 
-        let retrievedTools = defaults.array(forKey: "enabledTools") as? [String]
-        #expect(retrievedTools?.count == 3)
-        #expect(retrievedTools?.contains("calculator") == true)
-        #expect(retrievedTools?.contains("codeInterpreter") == true)
-        #expect(retrievedTools?.contains("webSearch") == true)
+        let retrievedData = defaults.data(forKey: "enabledToolsData")!
+        let retrievedTools = try! JSONDecoder().decode([String].self, from: retrievedData)
+        #expect(retrievedTools.count == 3)
+        #expect(retrievedTools.contains("calculator"))
+        #expect(retrievedTools.contains("codeInterpreter"))
+        #expect(retrievedTools.contains("webSearch"))
+
+        // Verify deterministic ordering
+        #expect(retrievedTools == ["calculator", "codeInterpreter", "webSearch"])
 
         // Update tools
         let updatedTools = ["calculator", "imageGenerator"]
-        defaults.set(updatedTools, forKey: "enabledTools")
+        let updatedEncoded = try! JSONEncoder().encode(updatedTools.sorted())
+        defaults.set(updatedEncoded, forKey: "enabledToolsData")
 
-        let newRetrievedTools = defaults.array(forKey: "enabledTools") as? [String]
-        #expect(newRetrievedTools?.count == 2)
-        #expect(newRetrievedTools?.contains("imageGenerator") == true)
-        #expect(newRetrievedTools?.contains("webSearch") == false)
+        let newData = defaults.data(forKey: "enabledToolsData")!
+        let newRetrievedTools = try! JSONDecoder().decode([String].self, from: newData)
+        #expect(newRetrievedTools.count == 2)
+        #expect(newRetrievedTools.contains("imageGenerator"))
+        #expect(!newRetrievedTools.contains("webSearch"))
+    }
+
+    @Test("Legacy enabledTools array migration")
+    func testLegacyEnabledToolsMigration() {
+        defer { cleanup() }
+
+        let defaults = UserDefaults.standard
+
+        // Simulate old-format data: a native array stored under "enabledTools"
+        let legacyTools = ["summarizer", "translator"]
+        defaults.set(legacyTools, forKey: "enabledTools")
+        #expect(defaults.array(forKey: "enabledTools") != nil)
+
+        // After migration the legacy key should be removed
+        // and the new key should contain sorted JSON
+        if let legacy = defaults.array(forKey: "enabledTools") as? [String] {
+            let data = try! JSONEncoder().encode(legacy.sorted())
+            defaults.set(data, forKey: "enabledToolsData")
+            defaults.removeObject(forKey: "enabledTools")
+        }
+
+        #expect(defaults.array(forKey: "enabledTools") == nil)
+        let migratedData = defaults.data(forKey: "enabledToolsData")!
+        let migrated = try! JSONDecoder().decode([String].self, from: migratedData)
+        #expect(migrated == ["summarizer", "translator"])
     }
 
     @Test("App preferences persistence")
@@ -258,6 +291,6 @@ extension SettingsTests {
         #expect(defaults.integer(forKey: "maxTokens") == 0) // Default int
         #expect(defaults.bool(forKey: "streamResponses") == false) // Default bool
         #expect(defaults.string(forKey: "selectedLanguageModel") == nil) // Default string
-        #expect(defaults.array(forKey: "enabledTools") == nil) // Default array
+        #expect(defaults.data(forKey: "enabledToolsData") == nil) // Default data
     }
 }


### PR DESCRIPTION
## Summary
- **Key migration**: Uses a new UserDefaults key `enabledToolsData` instead of reusing `enabledTools`, preventing type conflicts when existing users have native arrays stored under the old key
- **Deterministic encoding**: Sorts the `Set<String>` before JSON encoding so the stored JSON is stable across writes
- **Graceful failure**: Encoding failures no longer write empty `Data()` to UserDefaults — the previous value is preserved
- **Legacy migration**: On first appearance, migrates any existing `enabledTools` native-array value to the new key and removes the old key

Addresses Copilot feedback on PR #28.

## Test plan
- [x] Build succeeds on iOS Simulator
- [ ] Verify fresh install gets default tools (summarizer, translator, codeFormatter)
- [ ] Verify existing users with old `enabledTools` array key get migrated on first launch
- [ ] Verify toggling tools produces consistent JSON in UserDefaults
- [ ] Run unit tests (PrysmTests) — updated to cover new key and migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)