### PR TITLE
fix: Replace placeholder URLs with actual privacy policy and terms

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,63 @@
+# Privacy Policy
+
+**Last updated:** March 8, 2026
+
+## Introduction
+
+Prysm AI ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy explains how we handle your information when you use our app.
+
+## Information We Collect
+
+### Information You Provide
+- **Conversations**: Chat messages and interactions with the AI assistant
+- **Preferences**: App settings, themes, and customization choices
+- **Examples**: Custom prompts and templates you create
+
+### Information Automatically Collected
+- **Usage Data**: App launch counts, feature usage (for review prompt timing only)
+- **Device Info**: Device type (iPhone, iPad, Mac) for platform-specific optimizations
+- **Crash Data**: Anonymous crash reports (if enabled on your device)
+
+## How We Use Your Information
+
+- To provide and improve the AI assistant functionality
+- To save your preferences across app sessions
+- To generate appropriate review prompts
+- To diagnose and fix technical issues
+
+## Data Storage and Security
+
+- **On-Device Processing**: All AI conversations are processed locally on your device using Apple's Foundation Models framework
+- **Local Storage**: Your data is stored only on your device using SwiftData and UserDefaults
+- **No Cloud Sync**: We do not transmit your conversations to external servers
+- **No Third-Party Access**: We do not share your data with third parties
+
+## Your Rights
+
+You have the right to:
+- Delete all app data by uninstalling the app
+- Export your conversations (feature coming soon)
+- Control app permissions through iOS/macOS settings
+
+## Children's Privacy
+
+Our app is not intended for children under 13. We do not knowingly collect data from children under 13.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new policy in the app.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, please contact us:
+
+- GitHub Issues: https://github.com/andrewbierman/prysm/issues
+- Email: admin@biermancollective.com
+
+## California Privacy Rights
+
+California residents have additional rights under the CCPA. Please contact us for more information.
+
+## GDPR Compliance
+
+For users in the European Union, we comply with GDPR requirements. You have the right to access, rectify, or erase your personal data.

--- a/Prysm/Constants/AppConfig.swift
+++ b/Prysm/Constants/AppConfig.swift
@@ -180,10 +180,10 @@ enum AppConfig {
     static let supportURL = URL(string: "https://github.com/\(developerName.lowercased().replacingOccurrences(of: " ", with: ""))/\(appShortName.lowercased())")
 
     /// Privacy policy URL
-    static let privacyURL = URL(string: "https://example.com/privacy")
+    static let privacyURL = URL(string: "https://github.com/\(developerName.lowercased().replacingOccurrences(of: " ", with: ""))/\(appShortName.lowercased())/blob/main/PRIVACY.md")
 
     /// Terms of service URL
-    static let termsURL = URL(string: "https://example.com/terms")
+    static let termsURL = URL(string: "https://github.com/\(developerName.lowercased().replacingOccurrences(of: " ", with: ""))/\(appShortName.lowercased())/blob/main/TERMS.md")
 
     // MARK: - Version Info
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,95 @@
+# Terms of Service
+
+**Last updated:** March 8, 2026
+
+## Acceptance of Terms
+
+By downloading, installing, or using Prysm AI ("the App"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use the App.
+
+## Description of Service
+
+Prysm AI is an AI assistant application that uses Apple's Foundation Models framework to provide on-device AI capabilities. The App offers:
+- AI-powered conversations
+- Structured content generation
+- Customizable themes and settings
+- Example prompt library
+
+## Use License
+
+We grant you a limited, non-exclusive, non-transferable, revocable license to use the App for personal, non-commercial purposes.
+
+### You may:
+- Install and use the App on devices you own or control
+- Use the App for personal productivity and entertainment
+- Share feedback and suggestions
+
+### You may not:
+- Reverse engineer, decompile, or disassemble the App
+- Remove or alter any proprietary notices
+- Use the App for illegal purposes
+- Attempt to circumvent any security features
+- Resell, redistribute, or sublicense the App
+
+## User Content
+
+### Your Content
+You retain all rights to content you create within the App (conversations, custom prompts, etc.).
+
+### App Content
+All App content, including but not limited to:
+- Code and software
+- Design and graphics
+- Pre-built examples and templates
+- Documentation
+
+is owned by us and protected by copyright and other intellectual property laws.
+
+## Disclaimer of Warranties
+
+THE APP IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO:
+- WARRANTIES OF MERCHANTABILITY
+- FITNESS FOR A PARTICULAR PURPOSE
+- NON-INFRINGEMENT
+- ACCURACY OF AI GENERATED CONTENT
+
+## Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE SHALL NOT BE LIABLE FOR:
+- INDIRECT, INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES
+- LOSS OF PROFITS, DATA, OR GOODWILL
+- DAMAGES ARISING FROM APP USE OR INABILITY TO USE
+
+## AI-Generated Content
+
+You understand that:
+- AI-generated content may not always be accurate or appropriate
+- You should verify important information from AI responses
+- We are not responsible for decisions made based on AI-generated content
+- The App uses Apple's Foundation Models framework, and availability depends on Apple's services
+
+## Termination
+
+We may terminate or suspend your access to the App at any time, without prior notice, for any reason.
+
+## Changes to Terms
+
+We reserve the right to modify these Terms at any time. Continued use of the App after changes constitutes acceptance of the new Terms.
+
+## Governing Law
+
+These Terms shall be governed by the laws of the State of California, without regard to conflict of law principles.
+
+## Contact Information
+
+For questions about these Terms, please contact us:
+
+- GitHub Issues: https://github.com/andrewbierman/prysm/issues
+- Email: admin@biermancollective.com
+
+## Severability
+
+If any provision of these Terms is found to be unenforceable, the remaining provisions will continue in full force.
+
+## Entire Agreement
+
+These Terms constitute the entire agreement between you and us regarding the App.


### PR DESCRIPTION
Fixes placeholder URLs that were pointing to example.com.\n\n## Problem\nPrivacy Policy and Terms of Service URLs were pointing to non-existent example.com pages.\n\n## Solution\n- Updated URLs to point to GitHub repo\n- Created PRIVACY.md and TERMS.md\n\n## Changes\n- Modified AppConfig.swift\n- Created PRIVACY.md\n- Created TERMS.md